### PR TITLE
Add IPC integration with wintile for seamless window switching and tiling

### DIFF
--- a/src/IPC.h
+++ b/src/IPC.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <windows.h>
+
+constexpr UINT WM_SWABTAB_WINDOW_SELECTED = WM_USER + 100;
+constexpr UINT WM_WINTILE_SNAP_REQUEST = WM_USER + 101;
+
+constexpr const wchar_t* WINTILE_WINDOW_CLASS = L"WinVimTilerWindowClass";
+constexpr const wchar_t* SWABTAB_WINDOW_CLASS = L"TabSwitcherWindowClass";
+
+struct WindowSelectionData {
+    HWND selectedWindow;
+    DWORD processId;
+    wchar_t title[256];
+    wchar_t className[256];
+};

--- a/src/TabSwitcher.h
+++ b/src/TabSwitcher.h
@@ -68,7 +68,10 @@ private:
     void DrawIcon(HDC hdc, HICON icon, int x, int y);
     void DrawTextString(HDC hdc, const std::wstring& text, int x, int y, int width, COLORREF color);
     
+    void SendWindowSelectionToWintile(const WindowInfo& window);
+    bool IsWintileRunning();
+    
     // Constants
     static constexpr const wchar_t* WINDOW_CLASS_NAME = L"TabSwitcherWindowClass";
     static constexpr const wchar_t* WINDOW_TITLE = L"Tab Switcher";
-}; 
+};   


### PR DESCRIPTION
# Add IPC integration with wintile for seamless window switching and tiling

## Summary

This PR implements Inter-Process Communication (IPC) between swabtab (window switcher) and wintile (window tiler) to enable seamless workflow integration. When a user selects a window in swabtab, it now automatically positions the cursor at the center of that window, enabling immediate tiling operations with wintile.

**Key Changes:**
- Added `IPC.h` with shared constants and data structures for cross-process communication
- Implemented `SendWindowSelectionToWintile()` and `IsWintileRunning()` methods in `TabSwitcher` class
- Modified `ActivateSelectedWindow()` to send IPC messages to wintile when available
- Uses Windows `WM_COPYDATA` mechanism for safe cross-process data transfer
- Maintains full backward compatibility - both programs work independently when the other isn't running

## Review & Testing Checklist for Human

- [ ] **Test independent operation**: Verify both swabtab and wintile work normally when run separately (existing functionality unchanged)
- [ ] **Test integrated workflow**: Run both programs, use swabtab (RSHIFT) to select a window, verify cursor moves to window center, then test wintile tiling (Ctrl+Alt+HJKL) works on that window
- [ ] **Test error handling**: Start only one program and verify the other doesn't crash or hang when trying to communicate
- [ ] **Review memory safety**: Check `wcsncpy_s` usage and `COPYDATASTRUCT` handling for potential buffer overflows or memory issues
- [ ] **Verify data structure alignment**: Ensure `WindowSelectionData` struct is identical in both `IPC.h` files

**Recommended Test Plan:**
1. Build both programs on Windows
2. Test each program individually to ensure no regressions
3. Run both programs simultaneously and test the integrated workflow
4. Test edge cases (starting/stopping programs in different orders)
5. Monitor for memory leaks or stability issues during extended use

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "swabtab Repository"
        A["src/TabSwitcher.cpp"]:::major-edit
        B["src/TabSwitcher.h"]:::minor-edit
        C["src/IPC.h"]:::major-edit
        D["src/main.cpp"]:::context
    end
    
    subgraph "wintile Repository"
        E["main.cpp"]:::major-edit
        F["IPC.h"]:::major-edit
    end
    
    A -->|"calls SendWindowSelectionToWintile()"| C
    C -->|"WM_COPYDATA message"| F
    F -->|"handles in WndProc"| E
    E -->|"positions cursor on window"| G["Selected Window"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Platform Limitation**: Could not compile or test locally due to Windows-specific dependencies (windows.h not available on Linux development environment)
- **IPC Method**: Chose `WM_COPYDATA` over alternatives (named pipes, shared memory) because both programs already have Windows message loops
- **Cursor Strategy**: Positioning cursor at window center bridges swabtab's HWND-based selection with wintile's cursor-based window detection
- **Session Info**: Requested by Matti (@drvcvt) - [Devin Session](https://app.devin.ai/sessions/702e0483a4c04bdda07cefacd87b7e88)

**Critical Review Areas:**
- String handling safety in `WindowSelectionData` struct
- Message loop integration in `WndProc` 
- Error handling when target program is not running
- Memory management of `COPYDATASTRUCT`