### PR TITLE
Manage ownership of window icons

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -32,7 +32,9 @@ std::wstring GetProcessName(DWORD processId) {
     return L"";
 }
 
-HICON GetWindowIcon(HWND hwnd) {
+HICON GetWindowIcon(HWND hwnd, bool& destroyIcon) {
+    destroyIcon = false;
+
     // Try to get the icon from the window
     HICON icon = reinterpret_cast<HICON>(SendMessageW(hwnd, WM_GETICON, ICON_SMALL, 0));
     if (!icon) {
@@ -49,7 +51,7 @@ HICON GetWindowIcon(HWND hwnd) {
     if (!icon) {
         DWORD processId;
         GetWindowThreadProcessId(hwnd, &processId);
-        
+
         HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, processId);
         if (hProcess) {
             wchar_t exePath[MAX_PATH];
@@ -58,6 +60,7 @@ HICON GetWindowIcon(HWND hwnd) {
                 SHFILEINFOW fileInfo;
                 if (SHGetFileInfoW(exePath, 0, &fileInfo, sizeof(fileInfo), SHGFI_ICON | SHGFI_SMALLICON)) {
                     icon = fileInfo.hIcon;
+                    destroyIcon = true;
                 }
             }
             CloseHandle(hProcess);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -18,17 +18,97 @@ struct WindowInfo {
     bool isVisible;
     bool isMinimized;
     HICON icon;
+    bool destroyIcon;
     double score = 0.0;
-    
-    WindowInfo() : hwnd(nullptr), processId(0), isVisible(false), isMinimized(false), icon(nullptr), score(0.0) {}
+
+    WindowInfo()
+        : hwnd(nullptr), processId(0), isVisible(false),
+          isMinimized(false), icon(nullptr), destroyIcon(false),
+          score(0.0) {}
+
+    ~WindowInfo() {
+        if (destroyIcon && icon) {
+            DestroyIcon(icon);
+        }
+    }
+
+    WindowInfo(const WindowInfo& other)
+        : hwnd(other.hwnd), title(other.title), className(other.className),
+          processName(other.processName), processId(other.processId),
+          isVisible(other.isVisible), isMinimized(other.isMinimized),
+          icon(nullptr), destroyIcon(other.destroyIcon),
+          score(other.score) {
+        if (other.icon) {
+            icon = destroyIcon ? CopyIcon(other.icon) : other.icon;
+        }
+    }
+
+    WindowInfo& operator=(const WindowInfo& other) {
+        if (this != &other) {
+            if (destroyIcon && icon) {
+                DestroyIcon(icon);
+            }
+
+            hwnd = other.hwnd;
+            title = other.title;
+            className = other.className;
+            processName = other.processName;
+            processId = other.processId;
+            isVisible = other.isVisible;
+            isMinimized = other.isMinimized;
+            score = other.score;
+            destroyIcon = other.destroyIcon;
+
+            if (other.icon) {
+                icon = destroyIcon ? CopyIcon(other.icon) : other.icon;
+            } else {
+                icon = nullptr;
+            }
+        }
+        return *this;
+    }
+
+    WindowInfo(WindowInfo&& other) noexcept
+        : hwnd(other.hwnd), title(std::move(other.title)),
+          className(std::move(other.className)),
+          processName(std::move(other.processName)),
+          processId(other.processId), isVisible(other.isVisible),
+          isMinimized(other.isMinimized), icon(other.icon),
+          destroyIcon(other.destroyIcon), score(other.score) {
+        other.icon = nullptr;
+        other.destroyIcon = false;
+    }
+
+    WindowInfo& operator=(WindowInfo&& other) noexcept {
+        if (this != &other) {
+            if (destroyIcon && icon) {
+                DestroyIcon(icon);
+            }
+
+            hwnd = other.hwnd;
+            title = std::move(other.title);
+            className = std::move(other.className);
+            processName = std::move(other.processName);
+            processId = other.processId;
+            isVisible = other.isVisible;
+            isMinimized = other.isMinimized;
+            icon = other.icon;
+            destroyIcon = other.destroyIcon;
+            score = other.score;
+
+            other.icon = nullptr;
+            other.destroyIcon = false;
+        }
+        return *this;
+    }
 };
 
 // Utility functions
 namespace Utils {
     std::wstring GetProcessName(DWORD processId);
-    HICON GetWindowIcon(HWND hwnd);
+    HICON GetWindowIcon(HWND hwnd, bool& destroyIcon);
     void CenterWindow(HWND hwnd, int width, int height);
     bool IsValidWindow(HWND hwnd);
     UINT StringToVK(const std::string& key);
     UINT LoadHotkeySetting();
-} 
+}

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -99,9 +99,9 @@ WindowInfo WindowManager::CreateWindowInfo(HWND hwnd) {
     // Window state
     info.isVisible = IsWindowVisible(hwnd) != FALSE;
     info.isMinimized = IsIconic(hwnd) != FALSE;
-    
+
     // Get icon
-    info.icon = Utils::GetWindowIcon(hwnd);
+    info.icon = Utils::GetWindowIcon(hwnd, info.destroyIcon);
     
     return info;
 }


### PR DESCRIPTION
## Summary
- Track whether SHGetFileInfoW returned a window icon and note it for cleanup
- Add RAII-style management of `HICON` in `WindowInfo` with copy/move semantics
- Use the new icon ownership flag when collecting window info

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e6834571c83299538800005c21a6b