### PR TITLE
Normalize exclusion lists to lowercase

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <sstream>
 #include <algorithm>
+#include <cwctype>
 
 // Helper function to trim from both ends
 static inline std::wstring trim(const std::wstring& s) {
@@ -92,8 +93,14 @@ namespace Config {
         wchar_t buffer[2048];
         GetPrivateProfileStringW(L"WindowFilters", L"ExcludeProcessNames", L"", buffer, 2048, std::wstring(configPath.begin(), configPath.end()).c_str());
         EXCLUDED_PROCESSES = split(buffer, L',');
+        for (auto& proc : EXCLUDED_PROCESSES) {
+            std::transform(proc.begin(), proc.end(), proc.begin(), ::towlower);
+        }
 
         GetPrivateProfileStringW(L"WindowFilters", L"ExcludeTitles", L"", buffer, 2048, std::wstring(configPath.begin(), configPath.end()).c_str());
         EXCLUDED_TITLES = split(buffer, L',');
+        for (auto& title : EXCLUDED_TITLES) {
+            std::transform(title.begin(), title.end(), title.begin(), ::towlower);
+        }
     }
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -119,7 +119,9 @@ bool IsValidWindow(HWND hwnd) {
     if (!processName.empty()) {
         std::transform(processName.begin(), processName.end(), processName.begin(), ::towlower);
         for (const auto& excludedProc : Config::EXCLUDED_PROCESSES) {
-            if (processName == excludedProc) {
+            std::wstring lowerExcludedProc = excludedProc;
+            std::transform(lowerExcludedProc.begin(), lowerExcludedProc.end(), lowerExcludedProc.begin(), ::towlower);
+            if (processName == lowerExcludedProc) {
                 return false;
             }
         }
@@ -129,7 +131,9 @@ bool IsValidWindow(HWND hwnd) {
         std::wstring lowerTitle = titleStr;
         std::transform(lowerTitle.begin(), lowerTitle.end(), lowerTitle.begin(), ::towlower);
         for (const auto& excludedTitle : Config::EXCLUDED_TITLES) {
-            if (lowerTitle.find(excludedTitle) != std::wstring::npos) {
+            std::wstring lowerExcludedTitle = excludedTitle;
+            std::transform(lowerExcludedTitle.begin(), lowerExcludedTitle.end(), lowerExcludedTitle.begin(), ::towlower);
+            if (lowerTitle.find(lowerExcludedTitle) != std::wstring::npos) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Normalize `EXCLUDED_PROCESSES` and `EXCLUDED_TITLES` entries to lowercase upon config load to ensure case-insensitive filtering.
- Ensure runtime filtering in `IsValidWindow` also compares lowercased process names and titles for robustness.

## Testing
- `cmake --build build-gcc` *(fails: windows.h not found)*
- `sudo apt-get update` *(fails: repository not signed)*
- `g++ -std=c++17 /tmp/test_case.cpp -o /tmp/test_case && /tmp/test_case`


------
https://chatgpt.com/codex/tasks/task_e_688e699d3fc883299a0be4dd639b1dd2