### PR TITLE
Guard debug logging with DEBUG macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${PROJECT_NAME} WIN32 ${SOURCES} ${HEADERS})
 
 # Define NOMINMAX to prevent conflicts with Windows' min/max macros
 target_compile_definitions(${PROJECT_NAME} PRIVATE NOMINMAX)
+target_compile_definitions(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:DEBUG>)
 
 # Link Windows libraries
 if(WIN32)

--- a/src/TabSwitcher.cpp
+++ b/src/TabSwitcher.cpp
@@ -1,6 +1,8 @@
 #include "TabSwitcher.h"
-#include <iostream>
 #include <string>
+#ifdef DEBUG
+#include <iostream>
+#endif
 #include "Config.h"
 #include <windowsx.h>
 #include <dwmapi.h> // Include for DWM functions
@@ -301,10 +303,14 @@ void TabSwitcher::OnKeyDown(WPARAM vkCode, bool isShiftPressed) {
 
         case VK_TAB:
             if (isShiftPressed) {
+#ifdef DEBUG
                 std::cout << "Shift+Tab pressed - going backward" << std::endl;
+#endif
                 SelectPrevious();
             } else {
+#ifdef DEBUG
                 std::cout << "Tab pressed - going forward" << std::endl;
+#endif
                 SelectNext();
             }
             break;
@@ -361,10 +367,12 @@ void TabSwitcher::FilterWindows() {
         m_filteredWindows = m_windows;
     } else {
         // For debugging: convert wstring to string for cout
+#ifdef DEBUG
         std::string search_text_str;
         std::transform(m_searchText.begin(), m_searchText.end(), std::back_inserter(search_text_str),
                       [](wchar_t c) { return static_cast<char>(c); });
         std::cout << "Searching for: " << search_text_str << std::endl;
+#endif
 
         // Convert search text to lowercase for case-insensitive matching
         std::wstring search_lower = m_searchText;
@@ -372,13 +380,15 @@ void TabSwitcher::FilterWindows() {
 
         for (const auto& window : m_windows) {
             // For debugging: convert wstring to string for cout
+#ifdef DEBUG
             std::string window_title_str;
             std::transform(window.title.begin(), window.title.end(), std::back_inserter(window_title_str),
                           [](wchar_t c) { return static_cast<char>(c); });
-            
+
             std::string process_name_str;
             std::transform(window.processName.begin(), window.processName.end(), std::back_inserter(process_name_str),
                           [](wchar_t c) { return static_cast<char>(c); });
+#endif
 
             // Convert window title and process name to lowercase for case-insensitive matching
             std::wstring title_lower = window.title;
@@ -417,9 +427,11 @@ void TabSwitcher::FilterWindows() {
                 final_score += 10; // Small bonus for good process name matches
             }
             
-            std::cout << "Window: '" << window_title_str << "' (Process: '" << process_name_str << "')" 
-                      << " | Title Score: " << title_score << " | Process Score: " << process_score 
+#ifdef DEBUG
+            std::cout << "Window: '" << window_title_str << "' (Process: '" << process_name_str << "')"
+                      << " | Title Score: " << title_score << " | Process Score: " << process_score
                       << " | Final: " << final_score << std::endl;
+#endif
 
             // Use a threshold for quality results
             if (final_score > 60) {


### PR DESCRIPTION
## Summary
- wrap TabSwitcher debug output in `#ifdef DEBUG`
- define `DEBUG` macro for Debug builds so release builds emit no logs

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release` *(fails: `fatal error: windows.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_688e6aeaf97483298dfc0653680bfe98