### PR TITLE
Use wide-character Windows API for configuration

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -29,10 +29,10 @@ static std::vector<std::wstring> split(const std::wstring& s, wchar_t delimiter)
 }
 
 // Helper to parse color from "R,G,B" string
-static COLORREF parseColor(const std::string& colorStr, COLORREF defaultColor) {
-    std::stringstream ss(colorStr);
+static COLORREF parseColor(const std::wstring& colorStr, COLORREF defaultColor) {
+    std::wstringstream ss(colorStr);
     int r, g, b;
-    char comma;
+    wchar_t comma;
     if (ss >> r >> comma >> g >> comma >> b) {
         return RGB(r, g, b);
     }
@@ -57,47 +57,45 @@ namespace Config {
     std::vector<std::wstring> EXCLUDED_TITLES;
 
     void LoadConfig() {
-        char exePath[MAX_PATH];
-        GetModuleFileNameA(NULL, exePath, MAX_PATH);
-        std::string::size_type pos = std::string(exePath).find_last_of("\\/");
-        std::string configPath = std::string(exePath).substr(0, pos) + "\\config.ini";
+        wchar_t exePath[MAX_PATH];
+        GetModuleFileNameW(NULL, exePath, MAX_PATH);
+        std::wstring::size_type pos = std::wstring(exePath).find_last_of(L"\\/");
+        std::wstring configPath = std::wstring(exePath).substr(0, pos) + L"\\config.ini";
 
         // Appearance settings
-        WINDOW_WIDTH = GetPrivateProfileIntA("Appearance", "WindowWidth", 680, configPath.c_str());
-        WINDOW_HEIGHT = GetPrivateProfileIntA("Appearance", "WindowHeight", 450, configPath.c_str());
-        ITEM_HEIGHT = GetPrivateProfileIntA("Appearance", "ItemHeight", 40, configPath.c_str());
-        PADDING = GetPrivateProfileIntA("Appearance", "Padding", 15, configPath.c_str());
-        ICON_SIZE = GetPrivateProfileIntA("Appearance", "IconSize", 24, configPath.c_str());
+        WINDOW_WIDTH = GetPrivateProfileIntW(L"Appearance", L"WindowWidth", 680, configPath.c_str());
+        WINDOW_HEIGHT = GetPrivateProfileIntW(L"Appearance", L"WindowHeight", 450, configPath.c_str());
+        ITEM_HEIGHT = GetPrivateProfileIntW(L"Appearance", L"ItemHeight", 40, configPath.c_str());
+        PADDING = GetPrivateProfileIntW(L"Appearance", L"Padding", 15, configPath.c_str());
+        ICON_SIZE = GetPrivateProfileIntW(L"Appearance", L"IconSize", 24, configPath.c_str());
 
-        char fontNameStr[100];
-        GetPrivateProfileStringA("Appearance", "FontName", "Segoe UI", fontNameStr, 100, configPath.c_str());
-        int requiredSize = MultiByteToWideChar(CP_UTF8, 0, fontNameStr, -1, NULL, 0);
-        FONT_NAME.resize(requiredSize - 1);
-        MultiByteToWideChar(CP_UTF8, 0, fontNameStr, -1, &FONT_NAME[0], requiredSize);
+        wchar_t fontNameStr[100];
+        GetPrivateProfileStringW(L"Appearance", L"FontName", L"Segoe UI", fontNameStr, 100, configPath.c_str());
+        FONT_NAME = fontNameStr;
 
-        FONT_SIZE = GetPrivateProfileIntA("Appearance", "FontSize", 16, configPath.c_str());
+        FONT_SIZE = GetPrivateProfileIntW(L"Appearance", L"FontSize", 16, configPath.c_str());
 
-        char colorStr[50];
-        GetPrivateProfileStringA("Appearance", "BackgroundColor", "32,32,32", colorStr, 50, configPath.c_str());
+        wchar_t colorStr[50];
+        GetPrivateProfileStringW(L"Appearance", L"BackgroundColor", L"32,32,32", colorStr, 50, configPath.c_str());
         BG_COLOR = parseColor(colorStr, RGB(32, 32, 32));
-        GetPrivateProfileStringA("Appearance", "TextColor", "240,240,240", colorStr, 50, configPath.c_str());
+        GetPrivateProfileStringW(L"Appearance", L"TextColor", L"240,240,240", colorStr, 50, configPath.c_str());
         TEXT_COLOR = parseColor(colorStr, RGB(240, 240, 240));
-        GetPrivateProfileStringA("Appearance", "SelectedColor", "55,55,55", colorStr, 50, configPath.c_str());
+        GetPrivateProfileStringW(L"Appearance", L"SelectedColor", L"55,55,55", colorStr, 50, configPath.c_str());
         SELECTED_COLOR = parseColor(colorStr, RGB(55, 55, 55));
-        GetPrivateProfileStringA("Appearance", "HighlightColor", "0,120,215", colorStr, 50, configPath.c_str());
+        GetPrivateProfileStringW(L"Appearance", L"HighlightColor", L"0,120,215", colorStr, 50, configPath.c_str());
         HIGHLIGHT_COLOR = parseColor(colorStr, RGB(0, 120, 215));
-        GetPrivateProfileStringA("Appearance", "BorderColor", "80,80,80", colorStr, 50, configPath.c_str());
+        GetPrivateProfileStringW(L"Appearance", L"BorderColor", L"80,80,80", colorStr, 50, configPath.c_str());
         BORDER_COLOR = parseColor(colorStr, RGB(80, 80, 80));
 
         // Window Filters
         wchar_t buffer[2048];
-        GetPrivateProfileStringW(L"WindowFilters", L"ExcludeProcessNames", L"", buffer, 2048, std::wstring(configPath.begin(), configPath.end()).c_str());
+        GetPrivateProfileStringW(L"WindowFilters", L"ExcludeProcessNames", L"", buffer, 2048, configPath.c_str());
         EXCLUDED_PROCESSES = split(buffer, L',');
         for (auto& proc : EXCLUDED_PROCESSES) {
             std::transform(proc.begin(), proc.end(), proc.begin(), ::towlower);
         }
 
-        GetPrivateProfileStringW(L"WindowFilters", L"ExcludeTitles", L"", buffer, 2048, std::wstring(configPath.begin(), configPath.end()).c_str());
+        GetPrivateProfileStringW(L"WindowFilters", L"ExcludeTitles", L"", buffer, 2048, configPath.c_str());
         EXCLUDED_TITLES = split(buffer, L',');
         for (auto& title : EXCLUDED_TITLES) {
             std::transform(title.begin(), title.end(), title.begin(), ::towlower);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -152,84 +152,84 @@ bool IsValidWindow(HWND hwnd) {
     return true;
 }
 
-UINT StringToVK(const std::string& key) {
-    static const std::map<std::string, UINT> keyMap = {
-        {"LBUTTON", VK_LBUTTON},
-        {"RBUTTON", VK_RBUTTON},
-        {"CANCEL", VK_CANCEL},
-        {"MBUTTON", VK_MBUTTON},
-        {"XBUTTON1", VK_XBUTTON1},
-        {"XBUTTON2", VK_XBUTTON2},
-        {"BACK", VK_BACK},
-        {"TAB", VK_TAB},
-        {"CLEAR", VK_CLEAR},
-        {"RETURN", VK_RETURN},
-        {"SHIFT", VK_SHIFT},
-        {"CONTROL", VK_CONTROL},
-        {"ALT", VK_MENU},
-        {"PAUSE", VK_PAUSE},
-        {"CAPITAL", VK_CAPITAL},
-        {"ESCAPE", VK_ESCAPE},
-        {"SPACE", VK_SPACE},
-        {"PRIOR", VK_PRIOR},
-        {"NEXT", VK_NEXT},
-        {"END", VK_END},
-        {"HOME", VK_HOME},
-        {"LEFT", VK_LEFT},
-        {"UP", VK_UP},
-        {"RIGHT", VK_RIGHT},
-        {"DOWN", VK_DOWN},
-        {"SELECT", VK_SELECT},
-        {"PRINT", VK_PRINT},
-        {"EXECUTE", VK_EXECUTE},
-        {"SNAPSHOT", VK_SNAPSHOT},
-        {"INSERT", VK_INSERT},
-        {"DELETE", VK_DELETE},
-        {"HELP", VK_HELP},
-        {"LWIN", VK_LWIN},
-        {"RWIN", VK_RWIN},
-        {"APPS", VK_APPS},
-        {"SLEEP", VK_SLEEP},
-        {"NUMPAD0", VK_NUMPAD0},
-        {"NUMPAD1", VK_NUMPAD1},
-        {"NUMPAD2", VK_NUMPAD2},
-        {"NUMPAD3", VK_NUMPAD3},
-        {"NUMPAD4", VK_NUMPAD4},
-        {"NUMPAD5", VK_NUMPAD5},
-        {"NUMPAD6", VK_NUMPAD6},
-        {"NUMPAD7", VK_NUMPAD7},
-        {"NUMPAD8", VK_NUMPAD8},
-        {"NUMPAD9", VK_NUMPAD9},
-        {"MULTIPLY", VK_MULTIPLY},
-        {"ADD", VK_ADD},
-        {"SEPARATOR", VK_SEPARATOR},
-        {"SUBTRACT", VK_SUBTRACT},
-        {"DECIMAL", VK_DECIMAL},
-        {"DIVIDE", VK_DIVIDE},
-        {"F1", VK_F1},
-        {"F2", VK_F2},
-        {"F3", VK_F3},
-        {"F4", VK_F4},
-        {"F5", VK_F5},
-        {"F6", VK_F6},
-        {"F7", VK_F7},
-        {"F8", VK_F8},
-        {"F9", VK_F9},
-        {"F10", VK_F10},
-        {"F11", VK_F11},
-        {"F12", VK_F12},
-        {"NUMLOCK", VK_NUMLOCK},
-        {"SCROLL", VK_SCROLL},
-        {"LSHIFT", VK_LSHIFT},
-        {"RSHIFT", VK_RSHIFT},
-        {"LCONTROL", VK_LCONTROL},
-        {"RCONTROL", VK_RCONTROL},
-        {"LMENU", VK_LMENU},
-        {"RMENU", VK_RMENU}
+UINT StringToVK(const std::wstring& key) {
+    static const std::map<std::wstring, UINT> keyMap = {
+        {L"LBUTTON", VK_LBUTTON},
+        {L"RBUTTON", VK_RBUTTON},
+        {L"CANCEL", VK_CANCEL},
+        {L"MBUTTON", VK_MBUTTON},
+        {L"XBUTTON1", VK_XBUTTON1},
+        {L"XBUTTON2", VK_XBUTTON2},
+        {L"BACK", VK_BACK},
+        {L"TAB", VK_TAB},
+        {L"CLEAR", VK_CLEAR},
+        {L"RETURN", VK_RETURN},
+        {L"SHIFT", VK_SHIFT},
+        {L"CONTROL", VK_CONTROL},
+        {L"ALT", VK_MENU},
+        {L"PAUSE", VK_PAUSE},
+        {L"CAPITAL", VK_CAPITAL},
+        {L"ESCAPE", VK_ESCAPE},
+        {L"SPACE", VK_SPACE},
+        {L"PRIOR", VK_PRIOR},
+        {L"NEXT", VK_NEXT},
+        {L"END", VK_END},
+        {L"HOME", VK_HOME},
+        {L"LEFT", VK_LEFT},
+        {L"UP", VK_UP},
+        {L"RIGHT", VK_RIGHT},
+        {L"DOWN", VK_DOWN},
+        {L"SELECT", VK_SELECT},
+        {L"PRINT", VK_PRINT},
+        {L"EXECUTE", VK_EXECUTE},
+        {L"SNAPSHOT", VK_SNAPSHOT},
+        {L"INSERT", VK_INSERT},
+        {L"DELETE", VK_DELETE},
+        {L"HELP", VK_HELP},
+        {L"LWIN", VK_LWIN},
+        {L"RWIN", VK_RWIN},
+        {L"APPS", VK_APPS},
+        {L"SLEEP", VK_SLEEP},
+        {L"NUMPAD0", VK_NUMPAD0},
+        {L"NUMPAD1", VK_NUMPAD1},
+        {L"NUMPAD2", VK_NUMPAD2},
+        {L"NUMPAD3", VK_NUMPAD3},
+        {L"NUMPAD4", VK_NUMPAD4},
+        {L"NUMPAD5", VK_NUMPAD5},
+        {L"NUMPAD6", VK_NUMPAD6},
+        {L"NUMPAD7", VK_NUMPAD7},
+        {L"NUMPAD8", VK_NUMPAD8},
+        {L"NUMPAD9", VK_NUMPAD9},
+        {L"MULTIPLY", VK_MULTIPLY},
+        {L"ADD", VK_ADD},
+        {L"SEPARATOR", VK_SEPARATOR},
+        {L"SUBTRACT", VK_SUBTRACT},
+        {L"DECIMAL", VK_DECIMAL},
+        {L"DIVIDE", VK_DIVIDE},
+        {L"F1", VK_F1},
+        {L"F2", VK_F2},
+        {L"F3", VK_F3},
+        {L"F4", VK_F4},
+        {L"F5", VK_F5},
+        {L"F6", VK_F6},
+        {L"F7", VK_F7},
+        {L"F8", VK_F8},
+        {L"F9", VK_F9},
+        {L"F10", VK_F10},
+        {L"F11", VK_F11},
+        {L"F12", VK_F12},
+        {L"NUMLOCK", VK_NUMLOCK},
+        {L"SCROLL", VK_SCROLL},
+        {L"LSHIFT", VK_LSHIFT},
+        {L"RSHIFT", VK_RSHIFT},
+        {L"LCONTROL", VK_LCONTROL},
+        {L"RCONTROL", VK_RCONTROL},
+        {L"LMENU", VK_LMENU},
+        {L"RMENU", VK_RMENU}
     };
 
-    std::string upperKey = key;
-        std::transform(upperKey.begin(), upperKey.end(), upperKey.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    std::wstring upperKey = key;
+    std::transform(upperKey.begin(), upperKey.end(), upperKey.begin(), [](wchar_t c) { return static_cast<wchar_t>(std::towupper(c)); });
 
     auto it = keyMap.find(upperKey);
     if (it != keyMap.end()) {
@@ -238,9 +238,9 @@ UINT StringToVK(const std::string& key) {
 
     // For alphanumeric keys
     if (upperKey.length() == 1) {
-        char c = upperKey[0];
-        if ((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
-            return VkKeyScanA(c);
+        wchar_t c = upperKey[0];
+        if ((c >= L'A' && c <= L'Z') || (c >= L'0' && c <= L'9')) {
+            return static_cast<UINT>(VkKeyScanW(c));
         }
     }
 
@@ -248,13 +248,13 @@ UINT StringToVK(const std::string& key) {
 }
 
 UINT LoadHotkeySetting() {
-    char exePath[MAX_PATH];
-    GetModuleFileNameA(NULL, exePath, MAX_PATH);
-    std::string::size_type pos = std::string(exePath).find_last_of("\\/");
-    std::string configPath = std::string(exePath).substr(0, pos) + "\\config.ini";
+    wchar_t exePath[MAX_PATH];
+    GetModuleFileNameW(NULL, exePath, MAX_PATH);
+    std::wstring::size_type pos = std::wstring(exePath).find_last_of(L"\\/");
+    std::wstring configPath = std::wstring(exePath).substr(0, pos) + L"\\config.ini";
 
-    char hotkeyStr[50];
-    GetPrivateProfileStringA("Hotkeys", "Activation", "RSHIFT", hotkeyStr, 50, configPath.c_str());
+    wchar_t hotkeyStr[50];
+    GetPrivateProfileStringW(L"Hotkeys", L"Activation", L"RSHIFT", hotkeyStr, 50, configPath.c_str());
 
     UINT vkCode = StringToVK(hotkeyStr);
     if (vkCode == 0) {

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -109,6 +109,6 @@ namespace Utils {
     HICON GetWindowIcon(HWND hwnd, bool& destroyIcon);
     void CenterWindow(HWND hwnd, int width, int height);
     bool IsValidWindow(HWND hwnd);
-    UINT StringToVK(const std::string& key);
+    UINT StringToVK(const std::wstring& key);
     UINT LoadHotkeySetting();
 }


### PR DESCRIPTION
## Summary
- Switch GetModuleFileName and profile reads to wide-character Windows API.
- Handle all config paths and strings with `std::wstring`, removing manual conversions.
- Update hotkey parsing to accept wide strings.

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e6c8107288329a138247a3fd688b2