### PR TITLE
Highlight selected tab item with border and background

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -51,7 +51,7 @@ namespace Config {
     COLORREF BG_COLOR = RGB(32, 32, 32);
     COLORREF TEXT_COLOR = RGB(240, 240, 240);
     COLORREF SELECTED_COLOR = RGB(55, 55, 55);
-    COLORREF HIGHLIGHT_COLOR = RGB(0, 120, 215);
+    COLORREF SELECTED_BORDER_COLOR = RGB(0, 120, 215);
     COLORREF BORDER_COLOR = RGB(80, 80, 80);
     std::vector<std::wstring> EXCLUDED_PROCESSES;
     std::vector<std::wstring> EXCLUDED_TITLES;
@@ -82,8 +82,8 @@ namespace Config {
         TEXT_COLOR = parseColor(colorStr, RGB(240, 240, 240));
         GetPrivateProfileStringW(L"Appearance", L"SelectedColor", L"55,55,55", colorStr, 50, configPath.c_str());
         SELECTED_COLOR = parseColor(colorStr, RGB(55, 55, 55));
-        GetPrivateProfileStringW(L"Appearance", L"HighlightColor", L"0,120,215", colorStr, 50, configPath.c_str());
-        HIGHLIGHT_COLOR = parseColor(colorStr, RGB(0, 120, 215));
+        GetPrivateProfileStringW(L"Appearance", L"SelectedBorderColor", L"0,120,215", colorStr, 50, configPath.c_str());
+        SELECTED_BORDER_COLOR = parseColor(colorStr, RGB(0, 120, 215));
         GetPrivateProfileStringW(L"Appearance", L"BorderColor", L"80,80,80", colorStr, 50, configPath.c_str());
         BORDER_COLOR = parseColor(colorStr, RGB(80, 80, 80));
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -24,7 +24,7 @@ namespace Config {
     extern COLORREF BG_COLOR;
     extern COLORREF TEXT_COLOR;
     extern COLORREF SELECTED_COLOR;
-    extern COLORREF HIGHLIGHT_COLOR;
+    extern COLORREF SELECTED_BORDER_COLOR;
     extern COLORREF BORDER_COLOR;
 
     // Window Filters

--- a/src/TabSwitcher.cpp
+++ b/src/TabSwitcher.cpp
@@ -599,22 +599,17 @@ void TabSwitcher::DrawWindowItem(HDC hdc, const WindowInfo& window, int index, i
         clientRect.right - Config::PADDING, y + Config::ITEM_HEIGHT
     };
     
-    // Draw a custom selection cursor instead of filling the whole item
+    // Highlight selected item with background and border
     if (index == m_selectedIndex) {
-        //FillRect(hdc, &itemRect, m_selectedBrush);
-        HPEN highlightPen = CreatePen(PS_SOLID, 2, Config::HIGHLIGHT_COLOR);
-        //FrameRect(hdc, &itemRect, (HBRUSH)highlightPen);
-        
-        // Draw a ">" like cursor
-        HPEN oldPen = (HPEN)SelectObject(hdc, highlightPen);
-        int cursorY = y + Config::ITEM_HEIGHT / 2;
-        int cursorX = itemRect.left + 5;
-        MoveToEx(hdc, cursorX, cursorY - 5, nullptr);
-        LineTo(hdc, cursorX + 5, cursorY);
-        LineTo(hdc, cursorX, cursorY + 5);
-        SelectObject(hdc, oldPen);
+        FillRect(hdc, &itemRect, m_selectedBrush);
 
-        DeleteObject(highlightPen);
+        HPEN borderPen = CreatePen(PS_SOLID, 2, Config::SELECTED_BORDER_COLOR);
+        HGDIOBJ oldPen = SelectObject(hdc, borderPen);
+        HGDIOBJ oldBrush = SelectObject(hdc, GetStockObject(NULL_BRUSH));
+        Rectangle(hdc, itemRect.left, itemRect.top, itemRect.right, itemRect.bottom);
+        SelectObject(hdc, oldBrush);
+        SelectObject(hdc, oldPen);
+        DeleteObject(borderPen);
     }
     
     int x = itemRect.left + Config::PADDING + 15; // Indent text a bit more


### PR DESCRIPTION
## Summary
- add `SELECTED_BORDER_COLOR` configuration value
- fill selected item background and draw border instead of arrow cursor

## Testing
- `cmake --build build` (fails: fatal error: windows.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689a1b21ddb4832984a8dcb4045e2c6c