### PR TITLE
Add configurable preview width and keep thumbnail inside window

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -46,6 +46,7 @@ namespace Config {
     int ITEM_HEIGHT = 40;
     int PADDING = 15;
     int ICON_SIZE = 24;
+    int PREVIEW_WIDTH = 250;
     std::wstring FONT_NAME = L"Segoe UI";
     int FONT_SIZE = 16;
     COLORREF BG_COLOR = RGB(32, 32, 32);
@@ -63,11 +64,13 @@ namespace Config {
         std::wstring configPath = std::wstring(exePath).substr(0, pos) + L"\\config.ini";
 
         // Appearance settings
-        WINDOW_WIDTH = GetPrivateProfileIntW(L"Appearance", L"WindowWidth", 680, configPath.c_str());
+        int baseWidth = GetPrivateProfileIntW(L"Appearance", L"WindowWidth", 680, configPath.c_str());
         WINDOW_HEIGHT = GetPrivateProfileIntW(L"Appearance", L"WindowHeight", 450, configPath.c_str());
         ITEM_HEIGHT = GetPrivateProfileIntW(L"Appearance", L"ItemHeight", 40, configPath.c_str());
         PADDING = GetPrivateProfileIntW(L"Appearance", L"Padding", 15, configPath.c_str());
         ICON_SIZE = GetPrivateProfileIntW(L"Appearance", L"IconSize", 24, configPath.c_str());
+        PREVIEW_WIDTH = GetPrivateProfileIntW(L"Appearance", L"PreviewWidth", 250, configPath.c_str());
+        WINDOW_WIDTH = baseWidth + PREVIEW_WIDTH + PADDING * 2;
 
         wchar_t fontNameStr[100];
         GetPrivateProfileStringW(L"Appearance", L"FontName", L"Segoe UI", fontNameStr, 100, configPath.c_str());

--- a/src/Config.h
+++ b/src/Config.h
@@ -15,6 +15,7 @@ namespace Config {
     extern int ITEM_HEIGHT;
     extern int PADDING;
     extern int ICON_SIZE;
+    extern int PREVIEW_WIDTH;
 
     // Fonts
     extern std::wstring FONT_NAME;

--- a/src/TabSwitcher.cpp
+++ b/src/TabSwitcher.cpp
@@ -267,13 +267,14 @@ void TabSwitcher::OnPaint() {
                 GetClientRect(m_hwnd, &clientRect);
 
                 float aspectRatio = (float)sourceSize.cy / (float)sourceSize.cx;
-                int previewWidth = 250; // Thumbnail width
-                int previewHeight = (int)(previewWidth * aspectRatio);
+                int previewWidth = Config::PREVIEW_WIDTH;
+                int previewHeight = static_cast<int>(previewWidth * aspectRatio);
 
+                int previewLeft = clientRect.right - Config::PREVIEW_WIDTH - Config::PADDING;
                 RECT destRect = {
-                    clientRect.right + 10, // Position to the right of the main window
-                    (clientRect.bottom - previewHeight) / 2, // Centered vertically
-                    clientRect.right + 10 + previewWidth,
+                    previewLeft,
+                    (clientRect.bottom - previewHeight) / 2,
+                    previewLeft + previewWidth,
                     (clientRect.bottom - previewHeight) / 2 + previewHeight
                 };
 
@@ -562,6 +563,7 @@ void TabSwitcher::ActivateSelectedWindow() {
 void TabSwitcher::DrawWindow(HDC hdc) {
     RECT clientRect;
     GetClientRect(m_hwnd, &clientRect);
+    int previewLeft = clientRect.right - Config::PREVIEW_WIDTH - Config::PADDING;
     
     // The background is now handled by DWM (Mica/Acrylic), so we don't need to fill it.
     // FillRect(hdc, &clientRect, m_backgroundBrush);
@@ -582,7 +584,7 @@ void TabSwitcher::DrawWindow(HDC hdc) {
         std::wstring message = windowsEmpty ? L"Lade Fenster..." : L"Keine Fenster gefunden";
         DrawTextString(hdc, message, Config::PADDING,
                        y + (Config::ITEM_HEIGHT - 20) / 2,
-                       clientRect.right - 2 * Config::PADDING, Config::TEXT_COLOR);
+                       previewLeft - 2 * Config::PADDING, Config::TEXT_COLOR);
         SelectObject(hdc, oldFont);
         return;
     }
@@ -605,10 +607,11 @@ void TabSwitcher::DrawWindow(HDC hdc) {
 void TabSwitcher::DrawSearchBox(HDC hdc) {
     RECT clientRect;
     GetClientRect(m_hwnd, &clientRect);
+    int previewLeft = clientRect.right - Config::PREVIEW_WIDTH - Config::PADDING;
 
     RECT searchRect = {
         Config::PADDING, Config::PADDING,
-        clientRect.right - Config::PADDING, Config::PADDING + Config::ITEM_HEIGHT
+        previewLeft - Config::PADDING, Config::PADDING + Config::ITEM_HEIGHT
     };
     
     // A more subtle background for the search box
@@ -664,10 +667,11 @@ void TabSwitcher::DrawSearchBox(HDC hdc) {
 void TabSwitcher::DrawWindowItem(HDC hdc, const WindowInfo& window, int index, int y) {
     RECT clientRect;
     GetClientRect(m_hwnd, &clientRect);
-    
+    int previewLeft = clientRect.right - Config::PREVIEW_WIDTH - Config::PADDING;
+
     RECT itemRect = {
         Config::PADDING, y,
-        clientRect.right - Config::PADDING, y + Config::ITEM_HEIGHT
+        previewLeft - Config::PADDING, y + Config::ITEM_HEIGHT
     };
     
     // Draw a custom selection cursor instead of filling the whole item
@@ -730,13 +734,14 @@ void TabSwitcher::EnsureSelectionIsVisible() {
 RECT TabSwitcher::GetItemRect(int index) {
     RECT clientRect;
     GetClientRect(m_hwnd, &clientRect);
+    int previewLeft = clientRect.right - Config::PREVIEW_WIDTH - Config::PADDING;
 
     int relativeIndex = index - m_scrollOffset;
     int y = Config::PADDING + Config::ITEM_HEIGHT + (relativeIndex * Config::ITEM_HEIGHT);
 
     RECT itemRect = {
         Config::PADDING, y,
-        clientRect.right - Config::PADDING, y + Config::ITEM_HEIGHT
+        previewLeft - Config::PADDING, y + Config::ITEM_HEIGHT
     };
     return itemRect;
 }


### PR DESCRIPTION
## Summary
- make thumbnail preview width configurable and ensure window width accounts for it
- render DWM thumbnail inside the TabSwitcher client area
- update search box and window list to reserve space for the preview

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ae50b89508329859a7316edc1f993