### PR TITLE
Fix caret position calculation using std::min

### DIFF
--- a/src/TabSwitcher.cpp
+++ b/src/TabSwitcher.cpp
@@ -731,7 +731,7 @@ void TabSwitcher::DrawSearchBox(HDC hdc) {
 
     if (m_isCaretVisible) {
         int caretX = x + textSize.cx - scrollOffset;
-        caretX = min(caretX, searchRect.right - Config::PADDING);
+        caretX = std::min(caretX, static_cast<int>(searchRect.right - Config::PADDING));
         int caretY = searchRect.top + (Config::ITEM_HEIGHT - textHeight) / 2;
         int caretWidth = std::max(1, static_cast<int>(2 * m_scaleFactor));
         RECT caretRect = { caretX, caretY, caretX + caretWidth, caretY + textHeight };


### PR DESCRIPTION
## Summary
- cast caret bound to `int` so `std::min` resolves correctly when drawing the search caret

## Testing
- `cmake -S . -B build_dir`
- `cmake --build build_dir` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689af5b7bffc8329a62d53aa2eaf1186