### PR TITLE
Cache process names and icons for window enumeration

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -3,33 +3,38 @@
 #include <algorithm>
 #include <cctype>
 #include <cwctype>
-#include <tlhelp32.h>
 #include <shellapi.h>
-#include <map>
 #include <vector>
+#include <unordered_map>
+#include <filesystem>
+
+extern std::unordered_map<DWORD, std::wstring> g_processNameCache;
 
 namespace Utils {
 
 std::wstring GetProcessName(DWORD processId) {
-    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (hSnapshot == INVALID_HANDLE_VALUE) {
+    auto it = g_processNameCache.find(processId);
+    if (it != g_processNameCache.end()) {
+        return it->second;
+    }
+
+    HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
+    if (!hProcess) {
         return L"";
     }
 
-    PROCESSENTRY32W pe32;
-    pe32.dwSize = sizeof(PROCESSENTRY32W);
-
-    if (Process32FirstW(hSnapshot, &pe32)) {
-        do {
-            if (pe32.th32ProcessID == processId) {
-                CloseHandle(hSnapshot);
-                return std::wstring(pe32.szExeFile);
-            }
-        } while (Process32NextW(hSnapshot, &pe32));
+    wchar_t exePath[MAX_PATH];
+    DWORD size = MAX_PATH;
+    std::wstring result;
+    if (QueryFullProcessImageNameW(hProcess, 0, exePath, &size)) {
+        std::wstring fileName = std::filesystem::path(exePath).filename().wstring();
+        result = fileName;
     }
 
-    CloseHandle(hSnapshot);
-    return L"";
+    CloseHandle(hProcess);
+
+    g_processNameCache[processId] = result;
+    return result;
 }
 
 std::wstring RemoveFileExtension(const std::wstring& filename) {

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1,16 +1,48 @@
 #include "WindowManager.h"
 #include "Utils.h"
 #include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+
+struct IconCacheEntry {
+    HICON icon;
+    bool destroy;
+};
+
+std::unordered_map<DWORD, std::wstring> g_processNameCache;
+std::unordered_map<std::wstring, IconCacheEntry> g_iconCache;
 
 WindowManager::WindowManager() {
 }
 
 WindowManager::~WindowManager() {
+    for (auto& entry : g_iconCache) {
+        if (entry.second.destroy && entry.second.icon) {
+            DestroyIcon(entry.second.icon);
+        }
+    }
+    g_iconCache.clear();
 }
 
 std::vector<WindowInfo> WindowManager::GetAllWindows() {
     m_windows.clear();
     EnumWindows(EnumWindowsProc, reinterpret_cast<LPARAM>(this));
+
+    std::unordered_set<std::wstring> activeProcesses;
+    for (const auto& info : m_windows) {
+        activeProcesses.insert(info.processName);
+    }
+
+    for (auto it = g_iconCache.begin(); it != g_iconCache.end(); ) {
+        if (activeProcesses.find(it->first) == activeProcesses.end()) {
+            if (it->second.destroy && it->second.icon) {
+                DestroyIcon(it->second.icon);
+            }
+            it = g_iconCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
     return m_windows;
 }
 
@@ -89,7 +121,13 @@ WindowInfo WindowManager::CreateWindowInfo(HWND hwnd) {
     
     // Get process ID and name
     GetWindowThreadProcessId(hwnd, &info.processId);
-    info.processName = Utils::GetProcessName(info.processId);
+    auto procIt = g_processNameCache.find(info.processId);
+    if (procIt != g_processNameCache.end()) {
+        info.processName = procIt->second;
+    } else {
+        info.processName = Utils::GetProcessName(info.processId);
+        g_processNameCache[info.processId] = info.processName;
+    }
     
     // Append process name to title for better searchability
     if (!info.processName.empty()) {
@@ -101,7 +139,17 @@ WindowInfo WindowManager::CreateWindowInfo(HWND hwnd) {
     info.isMinimized = IsIconic(hwnd) != FALSE;
 
     // Get icon
-    info.icon = Utils::GetWindowIcon(hwnd, info.destroyIcon);
+    auto iconIt = g_iconCache.find(info.processName);
+    if (iconIt != g_iconCache.end()) {
+        info.icon = iconIt->second.icon;
+        info.destroyIcon = false;
+    } else {
+        IconCacheEntry entry{};
+        entry.icon = Utils::GetWindowIcon(hwnd, entry.destroy);
+        g_iconCache[info.processName] = entry;
+        info.icon = entry.icon;
+        info.destroyIcon = false;
+    }
     
     return info;
 }


### PR DESCRIPTION
## Summary
- Cache process names to avoid repeated `QueryFullProcessImageNameW` calls.
- Introduce icon cache so icons are loaded once per process and cleaned up when unused.
- Ensure icon resources are freed when windows close or the manager is destroyed.

## Testing
- `cmake --build build` *(fails: could not create CMAKE_GENERATOR "Visual Studio 17 2022"* )

------
https://chatgpt.com/codex/tasks/task_e_689d08d930648329b3efdeecadc8cefe