### PR TITLE
Use cached window list and notify background updater

### DIFF
--- a/src/TabSwitcher.cpp
+++ b/src/TabSwitcher.cpp
@@ -99,12 +99,16 @@ bool TabSwitcher::Create() {
 void TabSwitcher::Show() {
     if (m_isVisible.load()) return;
 
-    // Update the window list before showing the UI
+    // Use the existing window list; if it's empty, populate it once
     {
         std::lock_guard<std::mutex> lock(m_windowMutex);
-        m_windowManager->RefreshWindows();
-        m_windows = m_windowManager->GetAllWindows();
+        if (m_windows.empty()) {
+            m_windows = m_windowManager->GetAllWindows();
+        }
     }
+
+    // Ask the background thread to refresh immediately
+    m_updateCv.notify_one();
 
     m_searchText.clear();
     FilterWindows();
@@ -912,13 +916,16 @@ void TabSwitcher::StartWindowUpdater() {
 
 void TabSwitcher::StopWindowUpdater() {
     m_stopThread = true;
+    m_updateCv.notify_all();
     if (m_updateThread.joinable()) {
         m_updateThread.join();
     }
 }
 
 void TabSwitcher::UpdateWindowsInBackground() {
+    std::unique_lock<std::mutex> cvLock(m_updateCvMutex);
     while (!m_stopThread) {
+        cvLock.unlock();
         auto newWindows = m_windowManager->GetAllWindows();
         {
             std::lock_guard<std::mutex> lock(m_windowMutex);
@@ -930,7 +937,8 @@ void TabSwitcher::UpdateWindowsInBackground() {
             PostMessage(m_hwnd, WM_APP + 2, 0, 0); // Custom message to refresh
         }
 
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        cvLock.lock();
+        m_updateCv.wait_for(cvLock, std::chrono::seconds(2));
     }
 }
  

--- a/src/TabSwitcher.h
+++ b/src/TabSwitcher.h
@@ -16,6 +16,7 @@ constexpr UINT WM_APP_KEYDOWN = WM_APP + 1;
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include <condition_variable>
 
 class TabSwitcher {
 public:
@@ -59,6 +60,8 @@ private:
     // Threading for window updates
     std::thread m_updateThread;
     std::mutex m_windowMutex;
+    std::condition_variable m_updateCv;
+    std::mutex m_updateCvMutex;
     std::atomic<bool> m_stopThread;
     
     // UI state


### PR DESCRIPTION
## Summary
- Remove synchronous RefreshWindows call in TabSwitcher::Show and rely on cached list, triggering a fetch only when empty.
- Add condition variable-driven wake mechanism so the background thread can refresh windows on demand.

## Testing
- `cmake -S . -B /tmp/build`
- `cmake --build /tmp/build` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689da1b882bc8329be29ffb4950bcbe6