### PR TITLE
Use WinEvent hook for window updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,21 @@ To build the project, you need to have CMake and a C++ compiler (like MSVC from 
 5.  Press `Enter` to switch to the selected window.
 6.  Press `Esc` to hide the switcher without changing the window.
 
+## Window Event Hook
+
+The switcher keeps its window list updated using a WinEvent hook. During startup
+`StartWindowUpdater` registers a hook with `SetWinEventHook` for
+`EVENT_OBJECT_CREATE`, `EVENT_OBJECT_DESTROY` and `EVENT_SYSTEM_FOREGROUND`.
+Each event updates only the affected window entry.  When the application exits
+`StopWindowUpdater` automatically unregisters the hook.  If hook registration
+fails the switcher falls back to a slower polling mode.
+
 ## Changes Made
 
 - **Fixed Keyboard Input:** Repaired the faulty keyboard input handling that prevented the search functionality from working correctly. The application now properly processes keystrokes for searching and navigation.
 - **Changed Hotkey:** The hotkey to activate the switcher has been set to `RSHIFT`.
-- **Improved Stability:** Refactored the way keyboard events are passed from the global hook to the application window, preventing crashes and undefined behavior related to invalid memory access. 
+- **Improved Stability:** Refactored the way keyboard events are passed from the global hook to the application window, preventing crashes and undefined behavior related to invalid memory access.
+- **WinEvent Hook:** Window list updates now rely on a `SetWinEventHook` that tracks
+  window creation, destruction and foreground changes. The hook is registered at
+  startup and unhooked automatically on shutdown, with a polling fallback if the
+  registration fails.

--- a/src/TabSwitcher.cpp
+++ b/src/TabSwitcher.cpp
@@ -26,6 +26,8 @@
 #endif
 
 
+TabSwitcher* TabSwitcher::s_instance = nullptr;
+
 TabSwitcher::TabSwitcher()
     : m_hwnd(nullptr)
     , m_hThumbnail(nullptr)
@@ -38,7 +40,8 @@ TabSwitcher::TabSwitcher()
     , m_backgroundBrush(nullptr)
     , m_selectedBrush(nullptr)
     , m_stopThread(false) {
-    
+
+    s_instance = this;
     m_windowManager = std::make_unique<WindowManager>();
     RegisterWindowClass();
     StartWindowUpdater();
@@ -52,6 +55,7 @@ TabSwitcher::~TabSwitcher() {
     if (m_selectedBrush) DeleteObject(m_selectedBrush);
     if (m_hwnd) DestroyWindow(m_hwnd);
     UnregisterWindowClass();
+    s_instance = nullptr;
 }
 
 bool TabSwitcher::Create() {
@@ -107,8 +111,10 @@ void TabSwitcher::Show() {
         }
     }
 
-    // Ask the background thread to refresh immediately
-    m_updateCv.notify_one();
+    // Ask the background thread to refresh immediately if polling is active
+    if (m_useFallback) {
+        m_updateCv.notify_one();
+    }
 
     m_searchText.clear();
     FilterWindows();
@@ -909,36 +915,146 @@ bool TabSwitcher::BitapSearch(const std::wstring& text, const std::wstring& patt
 }
 
 void TabSwitcher::StartWindowUpdater() {
-    m_updateThread = std::thread([this] {
-        UpdateWindowsInBackground();
-    });
+    {
+        std::lock_guard<std::mutex> lock(m_windowMutex);
+        m_windows = m_windowManager->GetAllWindows();
+    }
+
+    if (!RegisterEventHooks()) {
+        m_useFallback = true;
+        m_updateThread = std::thread([this] { UpdateWindowsInBackground(); });
+    }
 }
 
 void TabSwitcher::StopWindowUpdater() {
-    m_stopThread = true;
-    m_updateCv.notify_all();
-    if (m_updateThread.joinable()) {
-        m_updateThread.join();
+    if (m_useFallback) {
+        m_stopThread = true;
+        m_updateCv.notify_all();
+        if (m_updateThread.joinable()) {
+            m_updateThread.join();
+        }
+    } else {
+        UnregisterEventHooks();
     }
 }
 
 void TabSwitcher::UpdateWindowsInBackground() {
     std::unique_lock<std::mutex> cvLock(m_updateCvMutex);
+    size_t lastCount = 0;
     while (!m_stopThread) {
         cvLock.unlock();
         auto newWindows = m_windowManager->GetAllWindows();
-        {
-            std::lock_guard<std::mutex> lock(m_windowMutex);
-            m_windows = std::move(newWindows);
-        }
+        if (newWindows.size() != lastCount) {
+            {
+                std::lock_guard<std::mutex> lock(m_windowMutex);
+                m_windows = std::move(newWindows);
+                lastCount = m_windows.size();
+            }
 
-        // If the window is visible, refresh the filtered list
-        if (m_isVisible.load()) {
-            PostMessage(m_hwnd, WM_APP + 2, 0, 0); // Custom message to refresh
+            // If the window is visible, refresh the filtered list
+            if (m_isVisible.load()) {
+                PostMessage(m_hwnd, WM_APP + 2, 0, 0); // Custom message to refresh
+            }
         }
 
         cvLock.lock();
-        m_updateCv.wait_for(cvLock, std::chrono::seconds(2));
+        m_updateCv.wait_for(cvLock, std::chrono::seconds(5));
+    }
+}
+
+bool TabSwitcher::RegisterEventHooks() {
+    DWORD flags = WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS;
+    m_hookCreate = SetWinEventHook(EVENT_OBJECT_CREATE, EVENT_OBJECT_CREATE, nullptr, WinEventProc, 0, 0, flags);
+    m_hookDestroy = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_DESTROY, nullptr, WinEventProc, 0, 0, flags);
+    m_hookForeground = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr, WinEventProc, 0, 0, flags);
+
+    if (m_hookCreate && m_hookDestroy && m_hookForeground) {
+        return true;
+    }
+
+    UnregisterEventHooks();
+    return false;
+}
+
+void TabSwitcher::UnregisterEventHooks() {
+    if (m_hookCreate) {
+        UnhookWinEvent(m_hookCreate);
+        m_hookCreate = nullptr;
+    }
+    if (m_hookDestroy) {
+        UnhookWinEvent(m_hookDestroy);
+        m_hookDestroy = nullptr;
+    }
+    if (m_hookForeground) {
+        UnhookWinEvent(m_hookForeground);
+        m_hookForeground = nullptr;
+    }
+}
+
+void CALLBACK TabSwitcher::WinEventProc(HWINEVENTHOOK, DWORD event, HWND hwnd, LONG idObject, LONG idChild,
+                                       DWORD, DWORD) {
+    if (s_instance) {
+        s_instance->HandleWinEvent(event, hwnd, idObject, idChild);
+    }
+}
+
+void TabSwitcher::HandleWinEvent(DWORD event, HWND hwnd, LONG idObject, LONG idChild) {
+    if (idObject != OBJID_WINDOW || hwnd == nullptr) {
+        return;
+    }
+
+    if (!m_windowManager->ShouldIncludeWindow(hwnd)) {
+        if (event == EVENT_OBJECT_DESTROY) {
+            std::lock_guard<std::mutex> lock(m_windowMutex);
+            m_windows.erase(std::remove_if(m_windows.begin(), m_windows.end(),
+                                           [hwnd](const WindowInfo& w) { return w.hwnd == hwnd; }),
+                            m_windows.end());
+        }
+        return;
+    }
+
+    switch (event) {
+    case EVENT_OBJECT_CREATE: {
+        WindowInfo info = m_windowManager->CreateWindowInfo(hwnd);
+        {
+            std::lock_guard<std::mutex> lock(m_windowMutex);
+            auto it = std::find_if(m_windows.begin(), m_windows.end(),
+                                   [hwnd](const WindowInfo& w) { return w.hwnd == hwnd; });
+            if (it == m_windows.end()) {
+                m_windows.push_back(info);
+            } else {
+                *it = info;
+            }
+        }
+        break;
+    }
+    case EVENT_OBJECT_DESTROY: {
+        std::lock_guard<std::mutex> lock(m_windowMutex);
+        m_windows.erase(std::remove_if(m_windows.begin(), m_windows.end(),
+                                       [hwnd](const WindowInfo& w) { return w.hwnd == hwnd; }),
+                        m_windows.end());
+        break;
+    }
+    case EVENT_SYSTEM_FOREGROUND: {
+        WindowInfo info = m_windowManager->CreateWindowInfo(hwnd);
+        {
+            std::lock_guard<std::mutex> lock(m_windowMutex);
+            auto it = std::find_if(m_windows.begin(), m_windows.end(),
+                                   [hwnd](const WindowInfo& w) { return w.hwnd == hwnd; });
+            if (it == m_windows.end()) {
+                m_windows.push_back(info);
+            } else {
+                *it = info;
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    if (m_isVisible.load()) {
+        PostMessage(m_hwnd, WM_APP + 2, 0, 0);
     }
 }
  

--- a/src/TabSwitcher.h
+++ b/src/TabSwitcher.h
@@ -42,6 +42,11 @@ private:
     void StartWindowUpdater();
     void StopWindowUpdater();
     void UpdateWindowsInBackground();
+    bool RegisterEventHooks();
+    void UnregisterEventHooks();
+    static void CALLBACK WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event, HWND hwnd,
+                                      LONG idObject, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime);
+    void HandleWinEvent(DWORD event, HWND hwnd, LONG idObject, LONG idChild);
 
     // Lightweight fuzzy match using Bitap/Shift-And
     bool BitapSearch(const std::wstring& text, const std::wstring& pattern, int maxErrors = 1);
@@ -63,6 +68,11 @@ private:
     std::condition_variable m_updateCv;
     std::mutex m_updateCvMutex;
     std::atomic<bool> m_stopThread;
+    bool m_useFallback{false};
+    HWINEVENTHOOK m_hookCreate{nullptr};
+    HWINEVENTHOOK m_hookDestroy{nullptr};
+    HWINEVENTHOOK m_hookForeground{nullptr};
+    static TabSwitcher* s_instance;
     
     // UI state
     int m_selectedIndex;

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -15,10 +15,14 @@ public:
     // Window operations
     bool ActivateWindow(HWND hwnd);
     bool IsWindowValid(HWND hwnd);
-    
+
     // Refresh window list
     void RefreshWindows();
-    
+
+    // Expose helper methods for single-window updates
+    WindowInfo CreateWindowInfo(HWND hwnd);
+    bool ShouldIncludeWindow(HWND hwnd);
+
 private:
     std::vector<WindowInfo> m_windows;
     
@@ -26,8 +30,6 @@ private:
     static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam);
     
     // Helper methods
-    WindowInfo CreateWindowInfo(HWND hwnd);
-    bool ShouldIncludeWindow(HWND hwnd);
     std::wstring GetWindowTitle(HWND hwnd);
     std::wstring GetWindowClassName(HWND hwnd);
-}; 
+};


### PR DESCRIPTION
## Summary
- Replace periodic polling with SetWinEventHook for create/destroy/foreground events
- Update only affected window entries and unregister hooks on shutdown
- Document hook lifecycle and add fallback polling logic

## Testing
- `cmake -S . -B build` (pass)
- `cmake --build build` (fails: windows.h not found)


------
https://chatgpt.com/codex/tasks/task_e_689da379db888329acdc40cffc9b1865