### PR TITLE
Precompute lowercase window info for faster search

### DIFF
--- a/src/TabSwitcher.cpp
+++ b/src/TabSwitcher.cpp
@@ -496,12 +496,6 @@ void TabSwitcher::FilterWindows() {
                            [](wchar_t c) { return static_cast<char>(c); });
 #endif
 
-            std::wstring title_lower = window.title;
-            std::transform(title_lower.begin(), title_lower.end(), title_lower.begin(), ::towlower);
-
-            std::wstring process_lower = Utils::RemoveFileExtension(window.processName);
-            std::transform(process_lower.begin(), process_lower.end(), process_lower.begin(), ::towlower);
-
             auto score_fn = [&](const std::wstring& target) -> double {
                 if (target.rfind(search_lower, 0) == 0)
                     return 100.0;
@@ -512,8 +506,8 @@ void TabSwitcher::FilterWindows() {
                 return 0.0;
             };
 
-            double title_score = score_fn(title_lower);
-            double process_score = score_fn(process_lower);
+            double title_score = score_fn(window.titleLower);
+            double process_score = score_fn(window.processLower);
             double final_score = std::max(title_score, process_score);
 
 #ifdef DEBUG

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -14,6 +14,8 @@ struct WindowInfo {
     std::wstring title;
     std::wstring className;
     std::wstring processName;
+    std::wstring titleLower;
+    std::wstring processLower;
     DWORD processId;
     bool isVisible;
     bool isMinimized;
@@ -34,7 +36,8 @@ struct WindowInfo {
 
     WindowInfo(const WindowInfo& other)
         : hwnd(other.hwnd), title(other.title), className(other.className),
-          processName(other.processName), processId(other.processId),
+          processName(other.processName), titleLower(other.titleLower),
+          processLower(other.processLower), processId(other.processId),
           isVisible(other.isVisible), isMinimized(other.isMinimized),
           icon(nullptr), destroyIcon(other.destroyIcon),
           score(other.score) {
@@ -53,6 +56,8 @@ struct WindowInfo {
             title = other.title;
             className = other.className;
             processName = other.processName;
+            titleLower = other.titleLower;
+            processLower = other.processLower;
             processId = other.processId;
             isVisible = other.isVisible;
             isMinimized = other.isMinimized;
@@ -72,6 +77,8 @@ struct WindowInfo {
         : hwnd(other.hwnd), title(std::move(other.title)),
           className(std::move(other.className)),
           processName(std::move(other.processName)),
+          titleLower(std::move(other.titleLower)),
+          processLower(std::move(other.processLower)),
           processId(other.processId), isVisible(other.isVisible),
           isMinimized(other.isMinimized), icon(other.icon),
           destroyIcon(other.destroyIcon), score(other.score) {
@@ -89,6 +96,8 @@ struct WindowInfo {
             title = std::move(other.title);
             className = std::move(other.className);
             processName = std::move(other.processName);
+            titleLower = std::move(other.titleLower);
+            processLower = std::move(other.processLower);
             processId = other.processId;
             isVisible = other.isVisible;
             isMinimized = other.isMinimized;

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -134,6 +134,13 @@ WindowInfo WindowManager::CreateWindowInfo(HWND hwnd) {
         info.title += L" (" + info.processName + L")";
     }
 
+    // Precompute lowercase variants for faster searching
+    info.titleLower = info.title;
+    std::transform(info.titleLower.begin(), info.titleLower.end(), info.titleLower.begin(), ::towlower);
+
+    info.processLower = Utils::RemoveFileExtension(info.processName);
+    std::transform(info.processLower.begin(), info.processLower.end(), info.processLower.begin(), ::towlower);
+
     // Window state
     info.isVisible = IsWindowVisible(hwnd) != FALSE;
     info.isMinimized = IsIconic(hwnd) != FALSE;

--- a/tests/case_insensitive_search_test.cpp
+++ b/tests/case_insensitive_search_test.cpp
@@ -1,0 +1,67 @@
+#include <cassert>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <cwctype>
+#include <iostream>
+
+struct WindowInfo {
+    std::wstring title;
+    std::wstring titleLower;
+    std::wstring processName;
+    std::wstring processLower;
+};
+
+std::vector<WindowInfo> Filter(const std::vector<WindowInfo>& windows, const std::wstring& search) {
+    std::vector<WindowInfo> filtered;
+    if (search.empty()) {
+        return windows;
+    }
+
+    std::wstring search_lower = search;
+    std::transform(search_lower.begin(), search_lower.end(), search_lower.begin(), ::towlower);
+
+    bool useFuzzy = search_lower.size() <= 2;
+    auto score_fn = [&](const std::wstring& target) -> double {
+        if (target.rfind(search_lower, 0) == 0)
+            return 100.0;
+        if (target.find(search_lower) != std::wstring::npos)
+            return 80.0;
+        if (useFuzzy) // simplified: no fuzzy search implementation needed for this test
+            return 0.0;
+        return 0.0;
+    };
+
+    for (const auto& w : windows) {
+        double title_score = score_fn(w.titleLower);
+        double process_score = score_fn(w.processLower);
+        double final_score = std::max(title_score, process_score);
+        if (final_score > 50)
+            filtered.push_back(w);
+    }
+    return filtered;
+}
+
+int main() {
+    WindowInfo info;
+    info.title = L"Some Title";
+    info.titleLower = L"some title";
+    info.processName = L"Other.EXE";
+    info.processLower = L"other";
+
+    std::vector<WindowInfo> windows{info};
+
+    // Title matches regardless of case
+    assert(Filter(windows, L"some").size() == 1);
+    assert(Filter(windows, L"SOME").size() == 1);
+
+    // Process name matches regardless of case
+    assert(Filter(windows, L"other").size() == 1);
+    assert(Filter(windows, L"OTHER").size() == 1);
+
+    // Non-matching query
+    assert(Filter(windows, L"missing").empty());
+
+    std::wcout << L"All tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Precompute `titleLower` and `processLower` for each window when gathering window info
- Use precomputed lowercase fields in window filtering logic
- Add unit test ensuring case-insensitive search works

## Testing
- `g++ -std=c++17 tests/case_insensitive_search_test.cpp -o tests/case_insensitive_search_test && ./tests/case_insensitive_search_test`
- `g++ -std=c++17 -c src/WindowManager.cpp` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689da7c3d7748329a71eb342c83fcff2